### PR TITLE
Add domain option to the logout set-cookie

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "strapi-v5-http-only-auth",
-  "version": "0.0.0",
+  "version": "1.0.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "strapi-v5-http-only-auth",
-      "version": "0.0.0",
+      "version": "1.0.2",
       "license": "MIT",
       "devDependencies": {
         "@strapi/sdk-plugin": "^5.3.0",

--- a/server/src/controllers/index.ts
+++ b/server/src/controllers/index.ts
@@ -1,10 +1,13 @@
 // import type { Core } from '@strapi/strapi';
 import type { Context } from 'koa';
+import { PLUGIN_ID } from '../constants';
 
 export default (/* { strapi }: { strapi: Core.Strapi } */) => ({
   logout: async (ctx: Context) => {
+    const options = strapi.plugin(PLUGIN_ID).config('cookieOptions');
+
     if (ctx.cookies.get('Auth')) {
-      ctx.cookies.set('Auth', null);
+      ctx.cookies.set('Auth', null, { ...(options as {}), maxAge: 0, expires: new Date(0) });
       ctx.body = { message: 'You have been logged out successfully.' };
       return;
     }


### PR DESCRIPTION
I found that when using it with a subdomain, the cookie is set for a domain only cookie (.domain.tld).
But the set cookie that is passed when logout does not contain the domain so the empty cookie is set at domain.tld, so... it does not remove the old one.